### PR TITLE
Allow external state callback to be specified via build flag...

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -612,6 +612,19 @@ static m64p_error ParseCommandLineFinal(int argc, const char **argv)
 /*********************************************************************************************************
 * main function
 */
+
+/* Allow state callback in external module to be specified via build flags (header and function name) */
+#ifdef CALLBACK_HEADER
+#define xstr(s) str(s)
+#define str(s) #s
+#include xstr(CALLBACK_HEADER)
+#endif
+
+#ifndef CALLBACK_FUNC
+#define CALLBACK_FUNC NULL
+#endif
+
+EXPORT
 int main(int argc, char *argv[])
 {
     int i;
@@ -633,7 +646,7 @@ int main(int argc, char *argv[])
         return 2;
 
     /* start the Mupen64Plus core library, load the configuration file */
-    m64p_error rval = (*CoreStartup)(CORE_API_VERSION, l_ConfigDirPath, l_DataDirPath, "Core", DebugCallback, NULL, NULL);
+    m64p_error rval = (*CoreStartup)(CORE_API_VERSION, l_ConfigDirPath, l_DataDirPath, "Core", DebugCallback, NULL, CALLBACK_FUNC);
     if (rval != M64ERR_SUCCESS)
     {
         DebugMessage(M64MSG_ERROR, "couldn't start Mupen64Plus core library.");


### PR DESCRIPTION
... and allow main() to be called by external module.

Useful for UI implementations that simply layer on top of ui-console
(rather than reimplement it).  In such cases, ui-console can be built as
a library rather than top-level executable.  The higher-level UI can
then "launch" the ui-console implementation in its own process/thread
by calling main directly (rather than spawning a separate ui-console
process).  This is not only a general convenience, but also allows the
higher-level UI to provide a state callback to synchronize its display.

This commit facilitates downstream UI development, but is not likely to
be of interest to general users who build ui-console from makefile.
Therefore, the CALLBACK_* build flags are omitted from the makefile help
text.