### PR TITLE
Fix windows build regression introduced in PR 12.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -624,7 +624,12 @@ static m64p_error ParseCommandLineFinal(int argc, const char **argv)
 #define CALLBACK_FUNC NULL
 #endif
 
-EXPORT
+#ifndef WIN32
+/* Allow external modules to call the main function as a library method.  This is useful for user
+ * interfaces that simply layer on top of (rather than re-implement) UI-Console (e.g. mupen64plus-ae).
+ */
+__attribute__ ((visibility("default")))
+#endif
 int main(int argc, char *argv[])
 {
     int i;


### PR DESCRIPTION
The EXPORT command breaks the build in windows due to conflicting
declaration of sdl_main by SDL_main.h, when built for WIN32.  No such
conflict exists for non-windows builds.

Here we just substitute the non-windows definition of EXPORT.