### PR TITLE
Drop architecture checks for cross-platform project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /projects/unix/_obj*/
-/projects/unix/mupen64plus-ui-console*.so
+/projects/unix/mupen64plus

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -52,10 +52,9 @@ ifeq ("$(OS)","NONE")
   $(error OS type "$(UNAME)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
 endif
 
-# detect system architecture
+# detect system architecture, only if it matters for build flags
 HOST_CPU ?= $(shell uname -m)
-NO_ASM ?= 1
-CPU := NONE
+CPU := OTHER
 ifneq ("$(filter x86_64 amd64,$(HOST_CPU))","")
   CPU := X86
   ifeq ("$(BITS)", "32")
@@ -67,28 +66,6 @@ endif
 ifneq ("$(filter pentium i%86,$(HOST_CPU))","")
   CPU := X86
   ARCH_DETECTED := 32BITS
-endif
-ifneq ("$(filter ppc macppc socppc powerpc,$(HOST_CPU))","")
-  CPU := PPC
-  ARCH_DETECTED := 32BITS
-  BIG_ENDIAN := 1
-  $(warning Architecture "$(HOST_CPU)" not officially supported.')
-endif
-ifneq ("$(filter ppc64 powerpc64,$(HOST_CPU))","")
-  CPU := PPC
-  ARCH_DETECTED := 64BITS
-  BIG_ENDIAN := 1
-  $(warning Architecture "$(HOST_CPU)" not officially supported.')
-endif
-ifneq ("$(filter arm%,$(HOST_CPU))","")
-  ifeq ("$(filter arm%b,$(HOST_CPU))","")
-    CPU := ARM
-    ARCH_DETECTED := 32BITS
-    $(warning Architecture "$(HOST_CPU)" not officially supported.')
-  endif
-endif
-ifeq ("$(CPU)","NONE")
-  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS


### PR DESCRIPTION
The Mupen64Plus Console UI is not sensitive to the architecture it's compiled for, only the operating system's dynamic linker and the flags used to build the plugins it loads.

I attach a commit that drops unnecessary architecture checks for this project, which means that new architecture ports have one less project to add a support stanza for in Unix Makefiles.

The .gitignore file additionally ignored the wrong binary file (mupen64plus-ui-console.so instead of mupen64plus).