### PR TITLE
New implementation of the savestate loaded at startup option.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -126,15 +126,6 @@ void DebugCallback(void *Context, int level, const char *message)
 
 static void FrameCallback(unsigned int FrameIndex)
 {
-    // load savestate at first frame if needed
-    if (l_SaveStatePath != NULL && FrameIndex == 0)
-    {
-        if ((*CoreDoCommand)(M64CMD_STATE_LOAD, 0, (void *) l_SaveStatePath) != M64ERR_SUCCESS)
-        {
-            DebugMessage(M64MSG_WARNING, "couldn't load state, rom will run normally.");
-        }
-    }
-
     // take a screenshot if we need to
     if (l_TestShotList != NULL)
     {
@@ -769,12 +760,21 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* set up Frame Callback if --testshots or --savestate is enabled */
-    if (l_TestShotList != NULL || l_SaveStatePath != NULL)
+    /* set up Frame Callback if --testshots is enabled */
+    if (l_TestShotList != NULL)
     {
         if ((*CoreDoCommand)(M64CMD_SET_FRAME_CALLBACK, 0, FrameCallback) != M64ERR_SUCCESS)
         {
-            DebugMessage(M64MSG_WARNING, "couldn't set frame callback, --testshots and/or --savestate will not work.");
+            DebugMessage(M64MSG_WARNING, "couldn't set frame callback, --testshots will not work.");
+        }
+    }
+
+    /* load savestate at startup */
+    if (l_SaveStatePath != NULL)
+    {
+        if ((*CoreDoCommand)(M64CMD_STATE_LOAD, 0, (void *) l_SaveStatePath) != M64ERR_SUCCESS)
+        {
+            DebugMessage(M64MSG_WARNING, "couldn't load state, rom will run normally.");
         }
     }
 


### PR DESCRIPTION
The savestate will be loaded on the first safe state interrupt instead of being loaded on the first frame.