### PR TITLE
bump macosx-version-min to 10.6 for SDL2.0.5

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -98,9 +98,9 @@ ifeq ($(OS), OSX)
 
   ifeq ($(CPU), X86)
     ifeq ($(ARCH_DETECTED), 64BITS)
-      CFLAGS += -pipe -arch x86_64 -mmacosx-version-min=10.5 -isysroot $(OSX_SDK_PATH)
+      CFLAGS += -pipe -arch x86_64 -mmacosx-version-min=10.6 -isysroot $(OSX_SDK_PATH)
     else
-      CFLAGS += -pipe -mmmx -msse -fomit-frame-pointer -arch i686 -mmacosx-version-min=10.5 -isysroot $(OSX_SDK_PATH)
+      CFLAGS += -pipe -mmmx -msse -fomit-frame-pointer -arch i686 -mmacosx-version-min=10.6 -isysroot $(OSX_SDK_PATH)
     endif
   endif
 endif


### PR DESCRIPTION
Allows for compilation on MacOS 10.12 Sierra using packages from Homebrew (samplerate speexdsp nasm and the sdl2 packages).