### PR TITLE
Add support for configuring window position

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,7 @@ Parameters:
     --fullscreen          : use fullscreen display mode
     --windowed            : use windowed display mode
     --resolution (res)    : display resolution (640x480, 800x600, 1024x768, etc)
+    --position (pos)      : window position (0,0; 100,100; 900,500; etc)
     --nospeedlimit        : disable core speed limiter (should be used with dummy audio plugin)
     --cheats (cheat-spec) : enable or list cheat codes for the given rom file
     --corelib (filepath)  : use core library (filepath) (can be only filename or full path)

--- a/doc/mupen64plus.6
+++ b/doc/mupen64plus.6
@@ -45,6 +45,8 @@ Run emulator in fullscreen display mode.
 Run emulator in windowed display mode.
 .It Fl Fl resolution Ar res
 Display resolution (640\(mu480, 800\(mu600, 1024\(mu768, etc)
+.It Fl Fl position Ar pos
+Window position (0,0, 100,100, 900,500, etc)
 .It Fl Fl nospeedlimit
 Disable core speed limiter.
 This should be used with the dummy audio plugin.

--- a/src/main.c
+++ b/src/main.c
@@ -255,6 +255,7 @@ static void printUsage(const char *progname)
            "    --fullscreen           : use fullscreen display mode\n"
            "    --windowed             : use windowed display mode\n"
            "    --resolution (res)     : display resolution (640x480, 800x600, 1024x768, etc)\n"
+           "    --position (pos)       : window position (0,0; 100,100; 900,500; etc)\n"
            "    --nospeedlimit         : disable core speed limiter (should be used with dummy audio plugin)\n"
            "    --cheats (cheat-spec)  : enable or list cheat codes for the given rom file\n"
            "    --corelib (filepath)   : use core library (filepath) (can be only filename or full path)\n"
@@ -495,6 +496,19 @@ static m64p_error ParseCommandLineFinal(int argc, const char **argv)
             {
                 (*ConfigSetParameter)(l_ConfigVideo, "ScreenWidth", M64TYPE_INT, &xres);
                 (*ConfigSetParameter)(l_ConfigVideo, "ScreenHeight", M64TYPE_INT, &yres);
+            }
+        }
+        else if (strcmp(argv[i], "--position") == 0 && ArgsLeft >= 1)
+        {
+            const char *pos = argv[i+1];
+            int xpos, ypos;
+            i++;
+            if (sscanf(pos, "%i,%i", &xpos, &ypos) != 2)
+                DebugMessage(M64MSG_WARNING, "couldn't parse window position '%s'", pos);
+            else
+            {
+                (*ConfigSetParameter)(l_ConfigCore, "ScreenPosX", M64TYPE_INT, &xpos);
+                (*ConfigSetParameter)(l_ConfigCore, "ScreenPosY", M64TYPE_INT, &ypos);
             }
         }
         else if (strcmp(argv[i], "--cheats") == 0 && ArgsLeft >= 1)


### PR DESCRIPTION
mupen64plus-core centres the window by default in windowed mode from what I can 

Support for other positions might be somewhat niche though I use it when programmatically spawning multiple instances, so that they can be tiled out rather than all be in the same spot.

These changes should allow a requested --position argument to be stored in the config as at least a preliminary step towards reading those during the creation of the window in core later on.

I stored the options in l_ConfigVideo at first but since it is handled in core and not the video plugins I stored them in l_ConfigCore instead

I have some changes to mupen64plus-core that reads the option and sets the window position, but I do not think those changes are nearly as clean as I feel these changes to ui-console 