### PR TITLE
Visual Studio 2015/SDL2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 1.0.{build}
+
+configuration:
+  - Release
+platform:
+  - x86
+  - x64
+
+before_build:
+- cmd: >-
+    git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ../mupen64plus-win32-deps
+    git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
+build:
+  project: projects/VisualStudio2015/mupen64plus-ui-console.vcxproj
+  verbosity: minimal

--- a/projects/VisualStudio2015/mupen64plus-ui-console.sln
+++ b/projects/VisualStudio2015/mupen64plus-ui-console.sln
@@ -4,15 +4,15 @@ VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-ui-console", "mupen64plus-ui-console.vcxproj", "{0E29D9F8-C675-4D21-AF16-AA80EDDB264E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-core", "..\..\..\mupen64plus-core\projects\VisualStudio2013\mupen64plus-core.vcxproj", "{92D3FEB9-2129-41C5-8577-BCD7D961EF41}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-core", "..\..\..\mupen64plus-core\projects\VisualStudio2015\mupen64plus-core.vcxproj", "{92D3FEB9-2129-41C5-8577-BCD7D961EF41}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-input-sdl", "..\..\..\mupen64plus-input-sdl\projects\VisualStudio2013\mupen64plus-input-sdl.vcxproj", "{7F3178D0-0E2E-471B-9160-69F0354F9DE9}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-input-sdl", "..\..\..\mupen64plus-input-sdl\projects\VisualStudio2015\mupen64plus-input-sdl.vcxproj", "{7F3178D0-0E2E-471B-9160-69F0354F9DE9}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-rsp-hle", "..\..\..\mupen64plus-rsp-hle\projects\VisualStudio2013\mupen64plus-rsp-hle.vcxproj", "{2EC7CEE3-C7A7-4F2E-B2C8-4DF6AFEC3E9A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-rsp-hle", "..\..\..\mupen64plus-rsp-hle\projects\VisualStudio2015\mupen64plus-rsp-hle.vcxproj", "{2EC7CEE3-C7A7-4F2E-B2C8-4DF6AFEC3E9A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-video-rice", "..\..\..\mupen64plus-video-rice\projects\VisualStudio2013\mupen64plus-video-rice.vcxproj", "{7D4AFF6A-B7D9-4C25-975A-038B8079098E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-audio-sdl", "..\..\..\mupen64plus-audio-sdl\projects\VisualStudio2013\mupen64plus-audio-sdl.vcxproj", "{96969748-EA54-43FC-8103-A346E9AD98E7}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-audio-sdl", "..\..\..\mupen64plus-audio-sdl\projects\VisualStudio2015\mupen64plus-audio-sdl.vcxproj", "{96969748-EA54-43FC-8103-A346E9AD98E7}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mupen64plus-video-glide64mk2", "..\..\..\mupen64plus-video-glide64mk2\projects\VisualStudio2013\mupen64plus-video-glide64mk2.vcxproj", "{A4D13408-A794-4199-8FC7-4A9A32505005}"
 EndProject

--- a/projects/VisualStudio2015/mupen64plus-ui-console.vcxproj
+++ b/projects/VisualStudio2015/mupen64plus-ui-console.vcxproj
@@ -28,23 +28,23 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -88,7 +88,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -100,7 +100,7 @@
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\SDLmain.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\SDL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\SDL2main.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -114,6 +114,7 @@ copy ..\..\..\mupen64plus-input-sdl\data\* "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\freetype-2.6\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\libpng-1.6.18\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\*.dll "$(OutDir)"
+copy ..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
 
 </Command>
@@ -122,7 +123,7 @@ copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -133,7 +134,7 @@ copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\SDLmain.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\SDL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\SDL2main.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -146,13 +147,14 @@ copy ..\..\..\mupen64plus-input-sdl\data\* "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\freetype-2.6\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\libpng-1.6.18\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\*.dll "$(OutDir)"
+copy ..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x64\*.dll "$(OutDir)"
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -162,7 +164,7 @@ copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x64\*.dll "$(OutDir)"
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\SDLmain.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\SDL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\SDL2main.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -178,6 +180,7 @@ copy ..\..\..\mupen64plus-input-sdl\data\* "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\freetype-2.6\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\libpng-1.6.18\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x86\*.dll "$(OutDir)"
+copy ..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x86\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
 
 </Command>
@@ -185,7 +188,7 @@ copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -195,7 +198,7 @@ copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x86\*.dll "$(OutDir)"
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\SDLmain.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\SDL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\SDL2main.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -210,6 +213,7 @@ copy ..\..\..\mupen64plus-input-sdl\data\* "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\freetype-2.6\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\libpng-1.6.18\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\SDL-1.2.15\lib\x64\*.dll "$(OutDir)"
+copy ..\..\..\mupen64plus-win32-deps\SDL2-2.0.6\lib\x64\*.dll "$(OutDir)"
 copy ..\..\..\mupen64plus-win32-deps\zlib-1.2.8\lib\x64\*.dll "$(OutDir)"
 </Command>
     </PostBuildEvent>


### PR DESCRIPTION
And add AppVeyor

I didn't modify glide64mk2 or rice right now. glide64mk2 is linked against a version of boost that uses v120, so we need a new version of boost. Both glide64mk2 and rice have some compilations failures when trying to use SDL2, some conflicts of the GL function definitions