### PR TITLE
Enhancements to debugging interface

### DIFF
--- a/README
+++ b/README
@@ -130,7 +130,18 @@ pc-1
   Print previous value of Program Counter register
 
 asm
-  Print assembly language instruction at current PC location
+  Print assembly language instructions. Several forms are supported:
+
+  asm                     Print one instruction at the Program Counter register
+
+  asm <addr>              Print one instruction at <addr>
+
+  asm <addr> <n>          Print <n> instructions starting at <addr>
+
+  asm <addr> <n> <flags>  Print <n> instructions starting at <addr> with flags
+    - If flags bit-3 is set (i.e. & 0x04): also print binary instruction data
+    - If flags bit-2 is set: prefix each instruction with its memory address
+    - If flags bit-1 is set: prefix each instruction with a counter from <addr>
 
 mem
   Print memory values. Several forms are supported:
@@ -149,8 +160,46 @@ mem
   mem /NxMw <addr>  Print <N> rows of <M> 32-bit words at <addr>
   mem /NxMd <addr>  Print <N> rows of <M> 64-bit double-words at <addr>
 
-bp add <addr>
-  Adds a breakpoint at a given address.
+write
+  Write values to memory. Several forms are supported:
+
+  write <addr> <value>    Write a (1) byte value to <addr>
+
+  write <addr> b <value>  Write a (1) byte value to <addr>
+  write <addr> h <value>  Write a half-word value (2 bytes) to <addr>
+  write <addr> w <value>  Write a word value (4 bytes) to <addr>
+  write <addr> d <value>  Write a double-word value (8 bytes) to <addr>
+
+translate
+  Translates virtual memory addresses to physical memory addresses. Memory
+  read/write breakpoints must operate on physical addresses, in contrast to the
+  memory read/write commands and execution breakpoints that operate on virtual
+  addresses.
+
+  translate <virtual address>  Print the 32-bit physical address for the
+                               provided <virtual address> argument.
+
+bp add
+  Adds a breakpoint at a given address. Several forms are supported:
+
+  bp add pc                  Add a breakpoint at the Program Counter, triggered
+                             on EXEC, READ, and WRITE.
+
+  bp add <addr>              Add a breakpoint at <addr>, triggered on EXEC,
+                             READ, and WRITE.
+
+  bp add <addr> <n>          Add a breakpoint starting at <addr>, extending <n>
+                             bytes, triggered on EXEC, READ, and WRITE.
+
+  bp add <addr> <n> <flags>  Add a breakpoint starting at <addr>, extending <n>
+                             bytes, with specified trigger flags.
+    - M64P_BKP_FLAG_READ = 0x02
+    - M64P_BKP_FLAG_WRITE = 0x04
+    - M64P_BKP_FLAG_EXEC = 0x08
+
+bp trig
+  Prints the reason for the most recently activated breakpoint trigger. Memory
+  read/write breakpoints will indicate the hit address.
 
 bp rm <addr|index>
   Removes a breakpoint by address or number.

--- a/src/core_interface.c
+++ b/src/core_interface.c
@@ -112,6 +112,7 @@ ptr_DebugBreakpointLookup  DebugBreakpointLookup = NULL;
 ptr_DebugBreakpointCommand DebugBreakpointCommand = NULL;
 
 ptr_DebugBreakpointTriggeredBy DebugBreakpointTriggeredBy = NULL;
+ptr_DebugVirtualToPhysical     DebugVirtualToPhysical = NULL;
 
 /* global variables */
 m64p_dynlib_handle CoreHandle = NULL;
@@ -302,6 +303,7 @@ m64p_error AttachCoreLib(const char *CoreLibFilepath)
     DebugBreakpointCommand = (ptr_DebugBreakpointCommand) osal_dynlib_getproc(CoreHandle, "DebugBreakpointCommand");
 
     DebugBreakpointTriggeredBy = (ptr_DebugBreakpointTriggeredBy) osal_dynlib_getproc(CoreHandle, "DebugBreakpointTriggeredBy");
+    DebugVirtualToPhysical = (ptr_DebugVirtualToPhysical) osal_dynlib_getproc(CoreHandle, "DebugVirtualToPhysical");
 
     return M64ERR_SUCCESS;
 }
@@ -371,6 +373,7 @@ m64p_error DetachCoreLib(void)
     DebugBreakpointCommand = NULL;
 
     DebugBreakpointTriggeredBy = NULL;
+    DebugVirtualToPhysical = NULL;
 
     /* detach the shared library */
     osal_dynlib_close(CoreHandle);

--- a/src/core_interface.c
+++ b/src/core_interface.c
@@ -111,6 +111,8 @@ ptr_DebugGetCPUDataPtr     DebugGetCPUDataPtr = NULL;
 ptr_DebugBreakpointLookup  DebugBreakpointLookup = NULL;
 ptr_DebugBreakpointCommand DebugBreakpointCommand = NULL;
 
+ptr_DebugBreakpointTriggeredBy DebugBreakpointTriggeredBy = NULL;
+
 /* global variables */
 m64p_dynlib_handle CoreHandle = NULL;
 
@@ -299,6 +301,8 @@ m64p_error AttachCoreLib(const char *CoreLibFilepath)
     DebugBreakpointLookup = (ptr_DebugBreakpointLookup) osal_dynlib_getproc(CoreHandle, "DebugBreakpointLookup");
     DebugBreakpointCommand = (ptr_DebugBreakpointCommand) osal_dynlib_getproc(CoreHandle, "DebugBreakpointCommand");
 
+    DebugBreakpointTriggeredBy = (ptr_DebugBreakpointTriggeredBy) osal_dynlib_getproc(CoreHandle, "DebugBreakpointTriggeredBy");
+
     return M64ERR_SUCCESS;
 }
 
@@ -365,6 +369,8 @@ m64p_error DetachCoreLib(void)
     DebugGetCPUDataPtr = NULL;
     DebugBreakpointLookup = NULL;
     DebugBreakpointCommand = NULL;
+
+    DebugBreakpointTriggeredBy = NULL;
 
     /* detach the shared library */
     osal_dynlib_close(CoreHandle);

--- a/src/core_interface.h
+++ b/src/core_interface.h
@@ -105,6 +105,7 @@ extern ptr_DebugBreakpointLookup  DebugBreakpointLookup;
 extern ptr_DebugBreakpointCommand DebugBreakpointCommand;
 
 extern ptr_DebugBreakpointTriggeredBy DebugBreakpointTriggeredBy;
+extern ptr_DebugVirtualToPhysical     DebugVirtualToPhysical;
 
 #endif /* #define CORE_INTERFACE_H */
 

--- a/src/core_interface.h
+++ b/src/core_interface.h
@@ -104,5 +104,7 @@ extern ptr_DebugGetCPUDataPtr     DebugGetCPUDataPtr;
 extern ptr_DebugBreakpointLookup  DebugBreakpointLookup;
 extern ptr_DebugBreakpointCommand DebugBreakpointCommand;
 
+extern ptr_DebugBreakpointTriggeredBy DebugBreakpointTriggeredBy;
+
 #endif /* #define CORE_INTERFACE_H */
 

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -457,6 +457,18 @@ int debugger_loop(void *arg) {
                 printf("Added breakpoint at 0x%08X.\n", addr);
             }
         }
+        else if (strncmp(input, "bp trig", 7) == 0) {
+            uint32_t flags, addr;
+            (*DebugBreakpointTriggeredBy)(&flags, &addr);
+
+            if (flags != 0) {
+                printf("Breakpoint @ PC 0x%08x triggered on 0x%08x [%c%c%c]\n",
+                       cur_pc, addr,
+                       flags & M64P_BKP_FLAG_READ ? 'R' : ' ',
+                       flags & M64P_BKP_FLAG_WRITE ? 'W' : ' ',
+                       flags & M64P_BKP_FLAG_EXEC ? 'X' : ' ');
+            }
+        }
         else if (strncmp(input, "bp rm ", 6) == 0) {
             int index = -1;
             unsigned int addr = 0;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -347,6 +347,16 @@ int debugger_loop(void *arg) {
                 printf("\n");
             }
         }
+        else if (strncmp(input, "translate", 9) == 0) {
+            uint32_t virt_addr, phys_addr;
+            if (sscanf(input, "translate %i", &virt_addr) == 1) {
+            } else {
+                printf("Improperly formatted translate command: '%s'\n", input);
+                continue;
+            }
+            phys_addr = (*DebugVirtualToPhysical)(virt_addr);
+            printf("virtual 0x%08x -> physical 0x%08x\n", virt_addr, phys_addr);
+        }
         else if (strncmp(input, "write", 5) == 0) {
             uint32_t writeAddr, size=1;
             uint64_t writeVal;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -249,9 +249,9 @@ int debugger_loop(void *arg) {
             if (sscanf(input, "asm %i %i %i", &addr, &size, &flags) == 3) {
             } else if (sscanf(input, "asm %i %i", &addr, &size) == 2) {
             } else if (sscanf(input, "asm %i", &addr) == 1) {
-            } else if (strcmp(input, "asm")) {
+            } else if (strcmp(input, "asm") == 0) {
             } else {
-                printf("Improperly formatted diassembly command: '%s'\n", input);
+                printf("Improperly formatted disassembly command: '%s'\n", input);
                 continue;
             }
             addr &= ~0x03; // align to 4 byte boundary

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -466,6 +466,15 @@ int debugger_loop(void *arg) {
             } else {
                 printf("Added breakpoint at 0x%08X.\n", addr);
             }
+
+            if (flags & (M64P_BKP_FLAG_READ | M64P_BKP_FLAG_WRITE)) {
+                // setting a memory read/write breakpoint -- warn if physical address differs from the user input
+                uint32_t phys_addr = (*DebugVirtualToPhysical)(addr);
+                if (phys_addr != 0 && addr != phys_addr) {
+                    printf("Warning: Physical address %08x != virtual address %08x for memory read/write breakpoint.\n",
+                            phys_addr, addr);
+                }
+            }
         }
         else if (strncmp(input, "bp trig", 7) == 0) {
             uint32_t flags, addr;


### PR DESCRIPTION
This pull request adds 3 new top-level commands ("write", "translate", "bp trig"), and significantly expands the capabilities of 2 existing commands ("asm" and "bp add") in the debugging command line interface.

- "write" allows writing 1, 2, 4, and 8 byte values to a specified virtual memory address
- "translate" translates virtual memory addresses to physical addresses (for memory breakpoints)
- "bp trig" prints the hit address for the most recent breakpoint; especially useful for memory breakpoints
- "asm" retains its existing 0-argument behavior of disassembling one instruction at the current PC location, but gains optional address, count, and flag arguments to disassemble (and format) machine instructions from other locations
- "bp add" retains its existing 1-argument behaviors (either "pc" or an address), but gains optional coverage size, and trigger flags (i.e. exec, read, write). Furthermore, if a user attempts to set a memory read/write breakpoint on a virtual address that resolves to a physical address, they will be warned of the difference.

These new behaviors are documented in the README changes that are part of this PR.