### PR TITLE
Improve startup time with input-sdl.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1018,6 +1018,17 @@ int main(int argc, char *argv[])
         return 11;
     }
 
+    /* Startup optimization:
+       Initializing the joystick subsystem is slow; input-sdl does it twice
+       unless the subsystem is already initialized, so do it first here. */
+    if (strncmp(
+                ConfigGetParamString(l_ConfigUI, "InputPlugin"),
+                "mupen64plus-input-sdl",
+                strlen("mupen64plus-input-sdl")
+               ) == 0)
+        if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == 1)
+            DebugMessage(M64MSG_ERROR, "Couldn't init SDL joystick subsystem: %s", SDL_GetError() );
+
     /* search for and load plugins */
     rval = PluginSearchLoad(l_ConfigUI);
     if (rval != M64ERR_SUCCESS)


### PR DESCRIPTION
The input-sdl plugin runs SDL_InitSubSystem(SDL_INIT_JOYSTICK) twice,
for about 0.6s each time. The separation is in order to account for
potential changes in physical joysticks between plugin loading and
plugin attaching. Such changes can reasonably happen in a GUI, where
there is time for the user to change joysticks, but not in the console
UI.

So, initialize the joystick subsystem first so that input-sdl will not
load and unload it.

For my benchmarks, this reduces run time (with configuration present
and using "--testshots 0") by approximately 0.51s (11.2%).

[original behavior]
real	0m4.565s
user	0m1.457s
sys	0m0.082s

real	0m4.566s
user	0m1.512s
sys	0m0.105s

real	0m4.621s
user	0m1.426s
sys	0m0.101s

[patched behavior]
real	0m4.058s
user	0m1.451s
sys	0m0.089s

real	0m4.044s
user	0m1.458s
sys	0m0.085s

real	0m4.114s
user	0m1.458s
sys	0m0.081s