### PR TITLE
build: Fix the build with 'cc' on gentoo.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -175,18 +175,22 @@ MKDIR ?= mkdir -p
 COMPILE.c = $(Q_CC)$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 LINK.o = $(Q_LD)$(CC) $(CFLAGS) $(LDFLAGS) $(TARGET_ARCH)
 
+ifndef PIE
+  ifeq ($(CC),$(CROSS_COMPILE)gcc)
+    # check if PIE is the default for the compiler
+    PIE_DEFAULT = $(shell $(CC) -v 2>&1 | grep enable-default-pie)
+    ifeq ($(PIE_DEFAULT),)
+      PIE = 1
+    endif
+  endif
+endif
+
 ifeq ($(PIE), 1)
   CFLAGS += -fPIE
   LDFLAGS += -pie
 else
   CFLAGS += -fno-PIE
-  ifeq ($(CC),$(CROSS_COMPILE)gcc)
-    # check if PIE is the default for the compiler
-    PIE_DEFAULT = $(shell $(CC) -v 2>&1 | grep enable-default-pie)
-    ifneq ($(PIE_DEFAULT),)
-      LDFLAGS += -no-pie
-    endif
-  endif
+  LDFLAGS += -no-pie
 endif
 
 # set installation options


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-ui-console/issues/65

See https://github.com/mupen64plus/mupen64plus-ui-console/issues/65#issuecomment-747644848

> I tested my above patch with `cc`, `gcc` and `clang` on both gentoo and slackware current using `PIE=0`, `PIE=1` and leaving `PIE` as the default without any issues. Its also worth noting the user can still use `make all PIE=1` or `make all PIE=0` to force the value regardless of the compiler. I think at the least its more robust than before.