### PR TITLE
fix build with mingw64

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -193,6 +193,20 @@ else
   LDFLAGS += -no-pie
 endif
 
+ifdef PIE
+  ifeq ($(PIE), 1)
+    CFLAGS += -fPIE
+    LDFLAGS += -pie
+  else
+    ifeq ($(PIE), 0)
+      CFLAGS += -fno-PIE
+      LDFLAGS += -no-pie
+    else
+      $(error Invalid PIE value.)
+    endif
+  endif
+endif
+
 # set installation options
 ifeq ($(PREFIX),)
   PREFIX := /usr/local


### PR DESCRIPTION
build failed with mingw64 due to usage of "PIE" option on system without explicit PIE