### PR TITLE
main.c: Fix 64DD ROM loading

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -886,6 +886,7 @@ static m64p_media_loader l_media_loader =
     NULL,
     media_loader_get_gb_cart_rom,
     media_loader_get_gb_cart_ram,
+    NULL,
     media_loader_get_dd_rom,
     media_loader_get_dd_disk
 };


### PR DESCRIPTION
Changes in https://github.com/mupen64plus/mupen64plus-core/commit/287ce77d816dc840a208c21a1f956ddb181e0bd0 broke loading 64DD ROMs using CLI.