### PR TITLE
core_interface.c: Don't force macOS app bundle path

### DIFF
--- a/src/core_interface.c
+++ b/src/core_interface.c
@@ -141,19 +141,22 @@ m64p_error AttachCoreLib(const char *CoreLibFilepath)
 #endif
     /* for MacOS, look for the library in the Frameworks folder of the app bundle */
 #if defined(__APPLE__)
-    CFBundleRef mainBundle = CFBundleGetMainBundle();
-    if (mainBundle != NULL)
+    if (rval != M64ERR_SUCCESS || CoreHandle == NULL)
     {
-        CFURLRef frameworksURL = CFBundleCopyPrivateFrameworksURL(mainBundle);
-        if (frameworksURL != NULL)
+        CFBundleRef mainBundle = CFBundleGetMainBundle();
+        if (mainBundle != NULL)
         {
-            char libPath[1024 + 32];
-            if (CFURLGetFileSystemRepresentation(frameworksURL, TRUE, (uint8_t *) libPath, 1024))
+            CFURLRef frameworksURL = CFBundleCopyPrivateFrameworksURL(mainBundle);
+            if (frameworksURL != NULL)
             {
-                strcat(libPath, "/" OSAL_DEFAULT_DYNLIB_FILENAME);
-                rval = osal_dynlib_open(&CoreHandle, libPath);
+                char libPath[1024 + 32];
+                if (CFURLGetFileSystemRepresentation(frameworksURL, TRUE, (uint8_t *) libPath, 1024))
+                {
+                    strcat(libPath, "/" OSAL_DEFAULT_DYNLIB_FILENAME);
+                    rval = osal_dynlib_open(&CoreHandle, libPath);
+                }
+                CFRelease(frameworksURL);
             }
-            CFRelease(frameworksURL);
         }
     }
 #endif


### PR DESCRIPTION
Currently the macOS app bundle path takes precedence over `--corelib` specified via command line. This technically prevents any CLI launcher that resides in an `.app` directory from loading the core file if that file is part of a non-standard directory and/or has its file name changed (e.g. `mupen64plus.dylib` instead of `libmupen64plus.dylib`).

This PR makes it so `core_interface` checks for a successful path first instead of simply overriding it, if macOS is detected.
I'm not entirely sure if this change is ultimately for the better, so I'm open for suggestions.