### PR TITLE
Remove SDL1 support

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -102,19 +102,21 @@ ifeq ($(OS), OSX)
   endif
 endif
 
+# test for essential build dependencies
+ifeq ($(origin PKG_CONFIG), undefined)
+  PKG_CONFIG = $(CROSS_COMPILE)pkg-config
+  ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null),)
+    $(error $(PKG_CONFIG) not found)
+  endif
+endif
+
 # test for presence of SDL
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-  SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
-  ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-    SDL_CONFIG = $(CROSS_COMPILE)sdl-config
-    ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-      $(error No SDL development libraries found!)
-    else
-      $(warning Using SDL 1.2 libraries)
-    endif
+  ifeq ($(shell $(PKG_CONFIG) --modversion sdl2 2>/dev/null),)
+    $(error No SDL2 development libraries found!)
   endif
-  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
-  SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
+  SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
+  SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl2)
 endif
 CFLAGS += $(SDL_CFLAGS)
 LDLIBS += $(SDL_LDLIBS)

--- a/src/main.c
+++ b/src/main.c
@@ -1120,11 +1120,7 @@ int main(int argc, char *argv[])
         int bEnableDebugger = 1;
         (*ConfigSetParameter)(l_ConfigCore, "EnableDebugger", M64TYPE_BOOL, &bEnableDebugger);
         /* Fork the debugger input thread. */
-#if SDL_VERSION_ATLEAST(2,0,0)
         SDL_CreateThread(debugger_loop, "DebugLoop", NULL);
-#else
-        SDL_CreateThread(debugger_loop, NULL);
-#endif
     }
     else
     {


### PR DESCRIPTION
Same as PR https://github.com/mupen64plus/mupen64plus-core/pull/1093

I'm not sure how much more cleanup for the SDL code is possible after this?

Closes: https://github.com/mupen64plus/mupen64plus-ui-console/issues/15