### PR TITLE
build: remove -fno-strict-aliasing

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -74,7 +74,7 @@ OBJDIR = _obj$(POSTFIX)
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
 
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -I$(SRCDIR)
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -I$(SRCDIR)
 ifeq ($(OS), MINGW)
   CFLAGS += -lpthread
   LDLIBS += -lpthread


### PR DESCRIPTION
It builds with -Werror=strict-aliasing so this should not be required.