### PR TITLE
Add lib64 to plugin search paths on unix

### DIFF
--- a/src/osal_files_unix.c
+++ b/src/osal_files_unix.c
@@ -37,8 +37,8 @@
 
 /* definitions for system directories to search when looking for mupen64plus plugins */
 #if defined(PLUGINDIR)
-  const int   osal_libsearchdirs = 4;
-  const char *osal_libsearchpath[4] = { PLUGINDIR, "/usr/local/lib/mupen64plus",  "/usr/lib/mupen64plus", "./" };
+  const int   osal_libsearchdirs = 5;
+  const char *osal_libsearchpath[5] = { PLUGINDIR, "/usr/local/lib/mupen64plus",  "/usr/lib/mupen64plus", "/usr/lib64/mupen64plus/", "./" };
 #else
   const int   osal_libsearchdirs = 3;
   const char *osal_libsearchpath[3] = { "/usr/local/lib/mupen64plus",  "/usr/lib/mupen64plus", "./" };


### PR DESCRIPTION
Fix the underlying issue of https://github.com/mupen64plus/mupen64plus-core/issues/1104