### PR TITLE
debugger: Add missing include

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -20,6 +20,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 


### PR DESCRIPTION
This becomes necessary when compiling with sdl2-compat for sdl3.